### PR TITLE
fix(docs): update release configuration link and remove limitations section from service connections documentation

### DIFF
--- a/docs/docker-to-iac/publishing-to-npm.md
+++ b/docs/docker-to-iac/publishing-to-npm.md
@@ -5,7 +5,7 @@ menuTitle: Publishing to NPM
 
 # Publishing docker-to-iac module to NPM
 
-We have created an organization @deploystack for NPM. Publishing in NPM happens automatically through `semantic-release`. Config: [https://github.com/deploystackio/docker-to-iac/blob/main/.github/workflows/release.yml](https://github.com/deploystackio/docker-to-iac/blob/main/.github/workflows/release.yml)
+We have created an organization @deploystack for NPM. Publishing in NPM happens automatically through `semantic-release`. Config: [https://github.com/deploystackio/docker-to-iac/blob/main/.github/workflows/release-pr.yml](https://github.com/deploystackio/docker-to-iac/blob/main/.github/workflows/release-pr.yml)
 
 The prerequisite for a release is a successful pull request to the default branch `main`. This means that all tests must first be successfully completed. `semantic-release` creates a new version and automatically publishes the node package to: [https://www.npmjs.com/package/@deploystack/docker-to-iac](https://www.npmjs.com/package/@deploystack/docker-to-iac)
 

--- a/docs/docker-to-iac/service-connections.md
+++ b/docs/docker-to-iac/service-connections.md
@@ -157,12 +157,6 @@ const serviceConnections = {
 // For Render - Will use fromService syntax instead of string replacement
 ```
 
-## Limitations
-
-- For Render.com, the module uses the `hostport` property which includes both hostname and port
-- The feature only transforms environment variables specifically mentioned in the configuration
-- Complex connection strings with multiple service references need each reference defined separately
-
 ## Response Format
 
 The `translate` function returns information about the resolved service connections:


### PR DESCRIPTION
## Description

fix(docs): update release configuration link and remove limitations section from service connections documentation

## Change Type

<!--- This is a comment, you can leave this to give information to the contributor -->

- [ ] Bug fix 
- [ ] New feature
- [ ] Breaking change
- [ ] Minor changes in old functionality

## Checklist

- [ ] My changes are well-tested and commented
- [ ] I reviewed my changes
- [ ] My changes generate no new warnings